### PR TITLE
Use flycheck-buffer-saved-p instead

### DIFF
--- a/flycheck-mix.el
+++ b/flycheck-mix.el
@@ -75,7 +75,10 @@
                    (flycheck-error-filename err))))
    errors)
  :modes (elixir-mode)
- :predicate (lambda () (and (flycheck-mix-project-root))))
+ :predicate (lambda ()
+              (and
+               (flycheck-buffer-saved-p)
+               (flycheck-mix-project-root))))
 
 (defun flycheck-mix-project-root ()
   "Return directory where =mix.exs= is located."
@@ -90,9 +93,6 @@
 ;;;###autoload
 (defun flycheck-mix-setup ()
   "Setup Flycheck for Elixir."
-  ;; it doesn't make sense to check buffer on idle change
-  ;; only saved files will be checked by mix
-  (setq flycheck-check-syntax-automatically '(mode-enabled save))
   (add-to-list 'flycheck-checkers 'elixir-mix))
 
 (provide 'flycheck-mix)


### PR DESCRIPTION
Fixes #1 

According to @lunaryorn, this is the typical way to ensure that the flychecker is only run on save.
